### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   pre-commit:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [dev, main]
 
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/FredrikM97/py-surepetcare/security/code-scanning/3](https://github.com/FredrikM97/py-surepetcare/security/code-scanning/3)

To fix this problem, we should explicitly add a `permissions` block to the workflow file to restrict the default permissions granted to the `GITHUB_TOKEN`. The least privilege required for standard checkout and test runs is `contents: read`, so this is the recommended setting at either the top level (applies to all jobs) or at the `jobs.test` level (for just this job). The best approach for maintainability is to add it at the root level, immediately after the workflow `name:` and `on:` blocks, and before `jobs:`. No other code or imports need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
