### PR TITLE
Make close_delay optional in Lid class

### DIFF
--- a/surepcio/devices/feeder_connect.py
+++ b/surepcio/devices/feeder_connect.py
@@ -32,7 +32,7 @@ class Bowls(ImprovedErrorMixin):
 
 
 class Lid(ImprovedErrorMixin):
-    close_delay: CloseDelay
+    close_delay: Optional[CloseDelay] = None
 
 
 class Control(BaseControl):


### PR DESCRIPTION
Solves issue where a new device crash if not properly setup in Surepetcare app