### PR TITLE
Fix is_curfew_active comparing UTC curfew times against local time

### DIFF
--- a/surepcio/devices/device.py
+++ b/surepcio/devices/device.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timezone
 import logging
 from abc import ABC
 from abc import abstractmethod
@@ -127,7 +128,9 @@ class DoorDeviceBase(DeviceBase[C, S]):
             if isinstance(curfew_value, list)
             else ([curfew_value] if curfew_value else [])
         )
-        now = datetime.now().time()
+        # The API reports curfew lock/unlock times in UTC, so compare
+        # against the current UTC time rather than the host's local time.
+        now = datetime.now(timezone.utc).time()
         return any(
             c.enabled
             and (

--- a/tests/surepcio/devices/test_door_device.py
+++ b/tests/surepcio/devices/test_door_device.py
@@ -1,7 +1,11 @@
+import os
+import time as time_module
 from datetime import datetime
 from datetime import time
+from datetime import timezone
 
 import pytest
+import time_machine
 
 from surepcio.devices.device import DoorDeviceBase
 from surepcio.devices.entities import BaseControl
@@ -23,8 +27,9 @@ class DummyDateTime:
     def __init__(self, fixed_datetime: datetime):
         self._fixed_datetime = fixed_datetime
 
-    def now(self):
-        return self._fixed_datetime
+    def now(self, tz=None):
+        assert tz is timezone.utc, "is_curfew_active must compare in UTC"
+        return self._fixed_datetime.replace(tzinfo=tz)
 
 
 @pytest.mark.parametrize(
@@ -80,3 +85,32 @@ def test_is_curfew_active_with_various_times(monkeypatch, curfew_values, now, ex
     monkeypatch.setattr("surepcio.devices.device.datetime", DummyDateTime(now))
 
     assert fake.is_curfew_active is expected
+
+
+@pytest.mark.skipif(
+    not hasattr(time_module, "tzset"), reason="requires POSIX tzset to change local time"
+)
+def test_is_curfew_active_uses_utc_not_host_local_time():
+    """Curfew times from the API are UTC; a host in UTC+1 must not shift the window."""
+    fake = FakeDoor({"id": 1, "household_id": 1})
+    fake.control = type(
+        "Control",
+        (),
+        {"curfew": [Curfew(enabled=True, lock_time=time(21, 0), unlock_time=time(5, 0))]},
+    )()
+
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Europe/London"  # UTC+1 (BST) on the frozen date
+    time_module.tzset()
+    try:
+        # 20:30 UTC is 21:30 local: local clock is past lock_time but UTC is not
+        with time_machine.travel("2026-07-06 20:30:00 +00:00", tick=False):
+            assert fake.is_curfew_active is False
+        with time_machine.travel("2026-07-06 21:30:00 +00:00", tick=False):
+            assert fake.is_curfew_active is True
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time_module.tzset()


### PR DESCRIPTION
The API reports curfew lock_time/unlock_time in UTC, but is_curfew_active compared them against the host's local wall clock. In any household whose local time differs from UTC (e.g. UK during BST), the curfew sensor flipped early or late by the UTC offset.

Compare against datetime.now(timezone.utc) instead, matching the convention already used in pet.py. Adds a regression test that pins the UTC behaviour under a UTC+1 host timezone using time-machine.

Fixes #84 